### PR TITLE
Serve files without index.html suffix

### DIFF
--- a/offline-archiver/server.py
+++ b/offline-archiver/server.py
@@ -75,7 +75,9 @@ def server_static(filepath, root_path):
     """Serve static files from the archive."""
     if filepath.endswith('/'):
         filepath += 'index.html'
-    if not os.path.splitext(filepath)[1]:
+    elif not os.path.splitext(filepath)[1]:
+        if os.path.isfile(os.path.join(root_path, filepath)):
+            return static_file(filepath, root=root_path)
         filepath = os.path.join(filepath, 'index.html')
     return static_file(filepath, root=root_path)
 


### PR DESCRIPTION
## Summary
- fix server static handler to fall back to the raw file before adding `index.html`

## Testing
- `curl -I http://localhost:8080/spells`
- `curl -I http://localhost:8080/spells%3Aartificer`

------
https://chatgpt.com/codex/tasks/task_e_685fb841e088833197775b12fd8649c4